### PR TITLE
Lists.parseListCreationInfo throws JSONException if unmatched identifiers are not strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,15 +67,15 @@ tasks.withType(Javadoc) {
 
 checkstyle {
   toolVersion '7.8.1'
-  configFile file("config/checkstyle/checkstyle.xml")
+  configFile file("$project.rootDir/config/checkstyle/checkstyle.xml")
   sourceSets = [sourceSets.main]
   showViolations = true
   ignoreFailures = false
   maxWarnings = 0
   //reportsDir = file("$project.rootDir/reports/checkstyle/$project.name")
   configProperties = [
-          'checkstyle.header.file': "config/checkstyle/copyright_header.txt",
-          'suppressionFile': "config/checkstyle/suppressions.xml"
+          'checkstyle.header.file': "$project.rootDir/config/checkstyle/copyright_header.txt",
+          'suppressionFile': "$project.rootDir/config/checkstyle/suppressions.xml"
   ]
 }
 

--- a/src/main/java/org/intermine/client/lists/Lists.java
+++ b/src/main/java/org/intermine/client/lists/Lists.java
@@ -95,7 +95,7 @@ public final class Lists
             if (jo.has("unmatchedIdentifiers")) {
                 JSONArray badIds = jo.getJSONArray("unmatchedIdentifiers");
                 for (int i = 0; i < badIds.length(); i++) {
-                    il.addUnmatchedId(badIds.getString(i));
+                    il.addUnmatchedId(badIds.optString(i));
                 }
             }
             return il;


### PR DESCRIPTION
Hi everyone, thanks for your work on Intermine. I found what I think is a bug in the Java client library and thought I would try to contribute a fix.

During list creation, if some unmatched identifiers are integers, which can happen if a list is specified using Entrez gene IDs, then we can have

``` 
"unmatchedIdentifiers":[
100909873,
100125377,
100910861, ...
```

which causes ServiceException at:

```
org.intermine.client.lists.Lists.parseListCreationInfo(Lists.java:103)
at org.intermine.client.services.ListService.processListCreationRequest(ListService.java:661)
at org.intermine.client.services.ListService.createList(ListService.java:236)
```

caused by

```
Caused by: org.json.JSONException: JSONArray[0] not a string.
at org.json.JSONArray.getString(JSONArray.java:333)
at org.intermine.client.lists.Lists.parseListCreationInfo(Lists.java:98)
```

The attached change to Lists here (optString(0) instead of getString(0)) fixes this and should not affect the case where the item is a String. 

I have tested this with my application and confirmed that it works, but unfortunately I wasn't able to run the intermine-ws-java test suite.

